### PR TITLE
Simplify local development setup with start-local.ps1 script for Podman

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,19 +75,13 @@ Install the following tools before starting:
 
 > **Why Podman?** Docker Desktop requires a paid licence in many organisations. Podman is a free, daemonless alternative that is fully compatible with Docker Compose files. The Dockerfiles in this project already use a non-root `appuser`, which is best-practice for Podman rootless mode.
 
-**Windows first-time setup:**
-
-```powershell
-# One-time machine initialisation (after installing Podman)
-podman machine init
-podman machine start
-```
-
 **Start the full stack:**
 
 ```powershell
-podman compose up --build
+.\scripts\start-local.ps1
 ```
+
+> On Windows this script automatically starts the Podman machine if it is not already running, so you do not need to run `podman machine start` manually before each session.
 
 **Verify everything works:**
 

--- a/README.md
+++ b/README.md
@@ -79,18 +79,13 @@ See [docs/current/capability-status.md](docs/current/capability-status.md) for t
 - [Podman](https://podman.io/docs/installation) 4.x or later (Docker Desktop is not used in this project)
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10) (for running tests and local development outside containers)
 
-> **Windows**: After installing Podman, open a new terminal and initialise the Podman machine once:
->
-> ```powershell
-> podman machine init
-> podman machine start
-> ```
-
 ### Run locally
 
 ```powershell
-podman compose up --build
+.\scripts\start-local.ps1
 ```
+
+> On Windows this script automatically starts the Podman machine if it is not already running, so you do not need to run `podman machine start` manually. On Linux and macOS it calls `podman compose up --build` directly.
 
 | Service | URL |
 | --- | --- |

--- a/scripts/start-local.ps1
+++ b/scripts/start-local.ps1
@@ -1,0 +1,61 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Starts the local TimeForCode stack using Podman Compose.
+
+.DESCRIPTION
+    On Windows, Podman requires a running Linux VM (Podman machine) before any
+    container commands can be issued. This script detects whether the machine is
+    running, starts (or initialises) it when necessary, and then delegates to
+    `podman compose up --build`.
+
+.EXAMPLE
+    .\scripts\start-local.ps1
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Info([string] $message) {
+    Write-Host $message -ForegroundColor Cyan
+}
+
+function Write-Success([string] $message) {
+    Write-Host $message -ForegroundColor Green
+}
+
+# ---------------------------------------------------------------------------
+# Podman machine check (Windows only)
+# ---------------------------------------------------------------------------
+
+if ($IsWindows) {
+    Write-Info "Checking Podman machine status..."
+
+    $machineList = podman machine list --format json 2>&1 | ConvertFrom-Json -ErrorAction SilentlyContinue
+
+    $runningMachine = $machineList | Where-Object { $_.Running -eq $true } | Select-Object -First 1
+
+    if ($runningMachine) {
+        Write-Success "Podman machine '$($runningMachine.Name)' is already running."
+    } else {
+        $existingMachine = $machineList | Select-Object -First 1
+
+        if ($existingMachine) {
+            Write-Info "Starting Podman machine '$($existingMachine.Name)'..."
+            podman machine start $existingMachine.Name
+        } else {
+            Write-Info "No Podman machine found. Initialising a new one (this takes a moment)..."
+            podman machine init
+            podman machine start
+        }
+
+        Write-Success "Podman machine is running."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Start the stack
+# ---------------------------------------------------------------------------
+
+Write-Info "Starting the TimeForCode stack..."
+podman compose up --build


### PR DESCRIPTION
Introduce a PowerShell script to streamline the local development process by automatically managing the Podman machine on Windows. This change eliminates the need for manual initialization steps and enhances the user experience for running the TimeForCode stack. The README and CONTRIBUTING documents have been updated accordingly.